### PR TITLE
Support prom-client@12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
       },
       "peerDependencies": {
         "ioredis": ">=5",
-        "prom-client": ">=14"
+        "prom-client": ">=12"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "ioredis": ">=5",
-    "prom-client": ">=14"
+    "prom-client": ">=12"
   },
   "engines": {
     "node": ">=20"

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,6 +1,6 @@
 import { Metric, Registry } from "prom-client";
 
-export const metrics: Metric[] = [];
+export const metrics: Metric<string>[] = [];
 
 export function registerMetrics(registry: Registry): void {
   for (const metric of metrics) {


### PR DESCRIPTION
Allows use in older codebases

Specifically to allow cache-kit to be used in ordering without needing to upgrade db-kit which requires upgrading major version of knex.
The change to allow it in cache-kit is a single word change, versus a possibly breaking change in ordering.

The only relevant difference in prom-client@14 (vs 12) is that the template parameter defaults to `string` if not specified in 14. So to be compatible, we specify it as was it defaults to in 14.