### PR TITLE
[ORD-3139] Update LRU only if key is already in store

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -45,7 +45,7 @@ metrics.push(
 
 export class Cache<const KT extends string> {
   private inflights = new Map<string, Promise<unknown>>();
-  private formatKey: (params: KeyParams<KT>) => string;
+  formatKey: (params: KeyParams<KT>) => string;
 
   constructor(
     private keyTemplate: KT,

--- a/src/lru.ts
+++ b/src/lru.ts
@@ -77,4 +77,11 @@ export class LruMemoryCacheStore<T> implements CacheStore<T> {
 
     return Promise.resolve();
   }
+
+  replace(key: string, record: StoreEntity<T>): Promise<void> {
+    if (this.cache.has(key)) {
+      return this.set(key, record);
+    }
+    return Promise.resolve();
+  }
 }


### PR DESCRIPTION
Internal tooling change only

[ORD-3139]

Add function to allow updating the LRU Cache, without forcibly pushing something else out if the key wasn't already in the LRU.

This isn't immediately useful (thought would be useful for tidy-www menu cache), but would still be helpful for optimistic updates.

## Submitter Checklist

Check only those that apply to this change.

- [x] Self-reviewed code, removed extraneous comments, debug logging, checked code style
- [ ] No change to users after merge (off-by-default configuration, feature flag, alt URL, etc.) and can be disabled if issues arise (if this is not the case we may need stakeholder signoff)
- [ ] Changes are documented (README, wiki, etc)
- [x] Automated tests added or existing tests cover the new functionality or changes
- [ ] ~~Manually tested changes~~
- [ ] ~~Metrics added to track the usage/performance~~
- [ ] ~~I am confident I can revert this change~~
- [ ] ~~Database migrations are reversible without data loss (if applicable)~~
- [ ] ~~Performance impact is acceptable (if applicable)~~
- [ ] ~~Any new dependencies are justified or have been approved (if applicable)~~
- [x] **This is NOT a high risk change** (if it is, please follow the high-risk change process)

### Testing Evidence

What evidence supports that you have tested this change?

- [x] Test cases cover the new functionality or changes
- [ ] ~~Screenshots or logs of the changes (if applicable)~~
- [ ] ~~Performance benchmarks (if applicable)~~
- [ ] ~~Storybook cases (if applicable)~~

## Reviewer Checklist

Note: if this PR affects authentication or payments please seek a secondary tester.

- [ ] I am ok with code style and functionality
- [ ] I have personally tested the feature
- [ ] My review was not rushed due to time constraints


[ORD-3139]: https://loke.atlassian.net/browse/ORD-3139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ