### PR TITLE
Add a Compressed Redis store

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ const cache = new Cache(
 );
 ```
 
+## CompressedRedisCacheStore
+
+`CompressedRedisCacheStore` acts as a drop in replacement for `RedisCacheStore`. It supports reading uncompressed content created by `RedisCacheStore`, and will compress the stored data if appropriate.
+
+```ts
+const cache = new Cache(
+  "foo-service:users:fetch:{userId}",
+  [
+    new LruMemoryCacheStore({ max: 1000 }),
+    new CompressedRedisCacheStore(redisClient),
+  ],
+  logger,
+);
+```
+
 ## TODO
 
 - [ ] JSON reviver support

--- a/src/compressed-redis.test.ts
+++ b/src/compressed-redis.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Redis from "ioredis";
+
+import { RedisCacheStore, CompressedRedisCacheStore } from ".";
+import { testCache } from "./storetest";
+
+const { REDIS_HOST = "localhost" } = process.env;
+
+test("CompressedRedisCacheStore", async (t) => {
+  const redisClient = new Redis(REDIS_HOST);
+  t.after(() => redisClient.quit());
+
+  const cache = new CompressedRedisCacheStore(redisClient);
+
+  await testCache(t, cache);
+
+  const uncompressedCache = new RedisCacheStore(redisClient);
+  uncompressedCache.setKeyTemplate("-- test --");
+
+  await t.test(
+    "CompressedRedisCacheStore can read RedisCacheStore entries",
+    async () => {
+      const key = "object";
+      const value = { a: 1, b: "c" };
+
+      const expiresAt = Date.now() + 5000;
+      await uncompressedCache.set(key, { value, expiresAt });
+
+      assert.deepEqual(await cache.get(key), { value, expiresAt });
+
+      await cache.delete(key);
+    },
+  );
+  await t.test(
+    "RedisCacheStore treats CachedRedisCacheStore entries as misses",
+    async () => {
+      const key = "object";
+      const value = { a: 1, b: "c" };
+
+      const expiresAt = Date.now() + 5000;
+      await cache.set(key, { value, expiresAt });
+
+      assert.deepEqual(await uncompressedCache.get(key), undefined);
+
+      await cache.delete(key);
+    },
+  );
+});

--- a/src/compressed-redis.test.ts
+++ b/src/compressed-redis.test.ts
@@ -36,12 +36,31 @@ test("CompressedRedisCacheStore", async (t) => {
     "RedisCacheStore treats CompressedRedisCacheStore entries as misses",
     async () => {
       const key = "object";
-      const value = { a: 1, b: "c" };
+      const value = { a: 1, b: "c", d: new Array(1024).fill(null) };
 
       const expiresAt = Date.now() + 5000;
       await cache.set(key, { value, expiresAt });
 
       assert.deepEqual(await uncompressedCache.get(key), undefined);
+
+      await cache.delete(key);
+    },
+  );
+  await t.test(
+    "CompressedRedisCacheStore works with both small and large objects",
+    async () => {
+      const key = "object";
+      const smallValue = { a: 1, b: "c" };
+      const largeValue = { a: 1, b: "c", d: new Array(1024).fill(null) };
+
+      const expiresAt = Date.now() + 5000;
+      await cache.set(key, { value: smallValue, expiresAt });
+
+      assert.deepEqual(await cache.get(key), { value: smallValue, expiresAt });
+
+      await cache.set(key, { value: largeValue, expiresAt });
+
+      assert.deepEqual(await cache.get(key), { value: largeValue, expiresAt });
 
       await cache.delete(key);
     },

--- a/src/compressed-redis.test.ts
+++ b/src/compressed-redis.test.ts
@@ -33,7 +33,7 @@ test("CompressedRedisCacheStore", async (t) => {
     },
   );
   await t.test(
-    "RedisCacheStore treats CachedRedisCacheStore entries as misses",
+    "RedisCacheStore treats CompressedRedisCacheStore entries as misses",
     async () => {
       const key = "object";
       const value = { a: 1, b: "c" };

--- a/src/compressed-redis.ts
+++ b/src/compressed-redis.ts
@@ -1,0 +1,106 @@
+import { exponentialBuckets, Histogram, linearBuckets } from "prom-client";
+import type {
+  Redis as IORedisClient,
+  Cluster as IORedisCluster,
+} from "ioredis";
+
+import type { CacheStore, StoreEntity } from "./store";
+import { metrics } from "./metrics";
+import { brotliCompress, brotliDecompress, constants } from "node:zlib";
+import { promisify } from "node:util";
+
+const brotliCompressAsync = promisify(brotliCompress);
+const brotliDecompressAsync = promisify(brotliDecompress);
+
+const cacheValueSize = new Histogram({
+  name: "cache_compressed_redis_value_size_bytes",
+  help: "Size of bytes sent to Redis after compression",
+  labelNames: ["key"],
+  buckets: exponentialBuckets(100, 10, 5),
+  registers: [],
+});
+
+const cacheCompressionRatio = new Histogram({
+  name: "cache_compressed_ratio",
+  help: "Ratio of uncompressed:compressed data",
+  labelNames: ["key"],
+  buckets: linearBuckets(0, 0.1, 11),
+  registers: [],
+});
+
+metrics.push(cacheValueSize, cacheCompressionRatio);
+
+type Client = Pick<IORedisClient | IORedisCluster, "getBuffer" | "set" | "del">;
+
+// Brotli looks like all the interesting options are on the compressor,
+// which wouldn't change the format of the stored data. But version the magic bytes just in case.
+// Br 26-03
+const brotli2603MagicBytes = Buffer.from([0x42, 0x72, 0x26, 0x03]);
+
+export class CompressedRedisCacheStore<T> implements CacheStore<T> {
+  private keyTemplate: string | null = null;
+
+  constructor(private client: Client) {}
+
+  setKeyTemplate(keyTemplate: string) {
+    if (this.keyTemplate !== null) {
+      throw new Error("Cannot change key template");
+    }
+
+    this.keyTemplate = keyTemplate;
+  }
+
+  async get(key: string): Promise<StoreEntity<T> | undefined> {
+    const rawData = await this.client.getBuffer(key);
+
+    if (rawData === null) return undefined;
+
+    if (
+      rawData
+        .subarray(0, brotli2603MagicBytes.length)
+        .equals(brotli2603MagicBytes)
+    ) {
+      return JSON.parse(
+        (
+          await brotliDecompressAsync(
+            rawData.subarray(brotli2603MagicBytes.length),
+          )
+        ).toString("utf8"),
+      );
+    }
+
+    try {
+      return JSON.parse(rawData.toString("utf8"));
+    } catch {
+      return undefined;
+    }
+  }
+
+  async set(key: string, record: StoreEntity<T>): Promise<void> {
+    const ttl = record.expiresAt - Date.now();
+    if (ttl <= 0) return;
+
+    const jsonBuffer = Buffer.from(JSON.stringify(record), "utf8");
+    const buf = Buffer.concat([
+      brotli2603MagicBytes,
+      await brotliCompressAsync(jsonBuffer, {
+        [constants.BROTLI_PARAM_MODE]: constants.BROTLI_MODE_TEXT,
+        [constants.BROTLI_PARAM_SIZE_HINT]: jsonBuffer.length,
+      }),
+    ]);
+
+    if (this.keyTemplate !== null) {
+      cacheValueSize.observe({ key: this.keyTemplate }, buf.length);
+      cacheCompressionRatio.observe(
+        { key: this.keyTemplate },
+        buf.length / jsonBuffer.length,
+      );
+    }
+
+    await this.client.set(key, buf, "PX", ttl);
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.del(key);
+  }
+}

--- a/src/compressed-redis.ts
+++ b/src/compressed-redis.ts
@@ -55,21 +55,21 @@ export class CompressedRedisCacheStore<T> implements CacheStore<T> {
 
     if (rawData === null) return undefined;
 
-    if (
-      rawData
-        .subarray(0, brotli2603MagicBytes.length)
-        .equals(brotli2603MagicBytes)
-    ) {
-      return JSON.parse(
-        (
-          await brotliDecompressAsync(
-            rawData.subarray(brotli2603MagicBytes.length),
-          )
-        ).toString("utf8"),
-      );
-    }
-
     try {
+      if (
+        rawData
+          .subarray(0, brotli2603MagicBytes.length)
+          .equals(brotli2603MagicBytes)
+      ) {
+        return JSON.parse(
+          (
+            await brotliDecompressAsync(
+              rawData.subarray(brotli2603MagicBytes.length),
+            )
+          ).toString("utf8"),
+        );
+      }
+
       return JSON.parse(rawData.toString("utf8"));
     } catch {
       return undefined;

--- a/src/compressed-redis.ts
+++ b/src/compressed-redis.ts
@@ -9,6 +9,14 @@ import { metrics } from "./metrics";
 import { brotliCompress, brotliDecompress, constants } from "node:zlib";
 import { promisify } from "node:util";
 
+/*
+Did benchmarking of the compression algorithms available in NodeJS.
+Zstd was the fastest to decompress, but is still experimental in the latest versions of Node.
+Brotli was the second contender, and is available in the versions of NodeJS used in our stack currently.
+
+Given that the data is going to be read far more than it's going to be written to, the cost of compression wasn't considered.
+*/
+
 const brotliCompressAsync = promisify(brotliCompress);
 const brotliDecompressAsync = promisify(brotliDecompress);
 

--- a/src/compressed-redis.ts
+++ b/src/compressed-redis.ts
@@ -89,6 +89,12 @@ export class CompressedRedisCacheStore<T> implements CacheStore<T> {
     if (ttl <= 0) return;
 
     const jsonBuffer = Buffer.from(JSON.stringify(record), "utf8");
+    // Don't pay the cost of compression for small enough objects
+    if (jsonBuffer.length < 1024) {
+      await this.client.set(key, jsonBuffer, "PX", ttl);
+      return;
+    }
+
     const buf = Buffer.concat([
       brotli2603MagicBytes,
       await brotliCompressAsync(jsonBuffer, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export * from "./store";
 export * from "./cache";
 export * from "./lru";
 export * from "./redis";
+export * from "./compressed-redis";
 export { registerMetrics } from "./metrics";


### PR DESCRIPTION
Allow reducing resource usage significantly at the cost of a slight amount of performance.

Compresses the JSON with Brotli before sending to the Redis store (and decompresses reading it back).
Adds magic bytes at the start of the data to identify the compression used, in case of new types (e.g. Zstd) in future when using newer versions of Node.

Split into other PR: Also make the (uncompressed) Redis store not error if it tries to read data encoded in a way it doesn't recognize. https://github.com/LOKE/cache-kit/pull/5

## Performance

Did benchmarking of the compression algorithms available in NodeJS. Zstd was the fastest to decompress, but is still experimental in the latest versions of Node. Brotli was the second contender.
Given that the data is going to be read far more than it's going to be written to, the cost of compression wasn't considered.

Knowing that the data is JSON allows setting a "text mode" parameter to the compression. In testing this didn't affect the size of the compressed data, but did improve the speed of decompression significantly.

It's untested, but in theory the extra compression could actually reduce transfer times enough to offset the extra time taken to perform the decompression, which was measured between 1ms and 2ms in testing.

## Rollout issues

This should be released as two changes - one making the uncompressed store more robust (https://github.com/LOKE/cache-kit/pull/5), then a second making the compressed store available. This would ensure that there are no JSON parsing exceptions during the roll out.


## Tests

- Unit tests pass the standard store tests.
- Compressed store can read values written uncompressed (by the existing redis store)
- The existing store can ignore compressed values
- Compressed store can store both uncompressed and compressed values

## Submitter Checklist

Check only those that apply to this change.

- [x] Self-reviewed code, removed extraneous comments, debug logging, checked code style
- [x] No change to users after merge (off-by-default configuration, feature flag, alt URL, etc.) and can be disabled if issues arise (if this is not the case we may need stakeholder signoff)
- [ ] Changes are documented (README, wiki, etc)
- [x] Automated tests added or existing tests cover the new functionality or changes
- [ ] Manually tested changes
- [x] Metrics added to track the usage/performance
- [x] I am confident I can revert this change
- [ ] ~~Database migrations are reversible without data loss (if applicable)~~
- [x] Performance impact is acceptable (if applicable)
- [ ] ~~Any new dependencies are justified or have been approved (if applicable)~~
- [x] **This is NOT a high risk change** (if it is, please follow the high-risk change process)

### Testing Evidence

What evidence supports that you have tested this change?

- [x] Test cases cover the new functionality or changes
- [ ] Screenshots or logs of the changes (if applicable)
- [ ] Performance benchmarks (if applicable)
- [ ] Storybook cases (if applicable)

## Reviewer Checklist

Note: if this PR affects authentication or payments please seek a secondary tester.

- [ ] I am ok with code style and functionality
- [ ] I have personally tested the feature
- [ ] My review was not rushed due to time constraints
